### PR TITLE
Update vsixmanifest to support Visual Studio 2019

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -13,6 +13,6 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26606.0,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26606.0,17.0)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Update to Microsoft.VisualStudio.Component.CoreEditor version number allows installation in Visual Studio 2019 to succeed.  Fixes #12 